### PR TITLE
Fixed and responsive screen ratios for canvas.

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -1,0 +1,28 @@
+body {
+    background: #000;
+    margin: 0;
+}
+
+#screen {
+    display: block;
+    image-rendering: pixelated;
+    position: absolute;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
+    width: 100vw;
+    max-height: 100vh;
+    --aspect-16-9: calc(9/16 * 100);
+    --aspect-4-3: calc(3/4 * 100);
+}
+
+[data-aspect-ratio="4:3"] {
+    height: calc(var(--aspect-4-3) * 1vw);
+    max-width: calc(100 / var(--aspect-4-3) * 100vh);
+}
+
+[data-aspect-ratio="16:9"] {
+    height: calc(var(--aspect-16-9) * 1vw);
+    max-width: calc(100 / var(--aspect-16-9) * 100vh);
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,23 +1,11 @@
 <!DOCTYPE html>
 <html>
-<head>
-    <title>Super Mario</title>
-    <style>
-        body {
-            background: #000;
-            margin: 0;
-        }
-
-        #screen {
-            display: block;
-            image-rendering: pixelated;
-            height: 100vh;
-            margin: auto;
-        }
-    </style>
-    <script type="module" src="/js/main.js"></script>
-</head>
-<body>
-    <canvas id="screen" width="256" height="240"></canvas>
-</body>
+    <head>
+        <title>Super Mario</title>
+        <link rel="stylesheet" href="/css/layout.css">
+        <script type="module" src="/js/main.js"></script>
+    </head>
+    <body>
+        <canvas id="screen" width="256" height="240" data-aspect-ratio="4:3"></canvas>
+    </body>
 </html>


### PR DESCRIPTION
Aspect ratios for #screen canvas.

- Supports 4:3 and 16:9.
- Keeps aspect upon resizing.
- Always full width or full height.
- Canvas centered if window width is greater than allowed height.
- No scrollbars (since it always fit).