### PR TITLE
Correct position for "WORLD" and level name.

### DIFF
--- a/public/js/layers/dashboard.js
+++ b/public/js/layers/dashboard.js
@@ -30,8 +30,8 @@ export function createDashboardLayer(font, level) {
 
         font.print('×' + playerTrait.coins.toString().padStart(2, '0'), context, 96, LINE2);
 
-        font.print('WORLD', context, 152, LINE1);
-        font.print(level.name, context, 160, LINE2);
+        font.print('WORLD', context, 144, LINE1);
+        font.print(level.name, context, 152, LINE2);
 
         font.print('TIME', context, 200, LINE1);
         font.print(timerTrait.currentTime.toFixed().toString().padStart(3, '0'), context, 208, LINE2);


### PR DESCRIPTION
Moved "WORLD" and level name 1 character left.