### PR TITLE
Aspect ratios for #screen.

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1,0 +1,22 @@
+body {
+    background: #000;
+    margin: 0;
+}
+
+#screen {
+    display: block;
+    image-rendering: pixelated;
+    margin: auto;
+    width: 100vw;
+    max-height: 100vh;
+}
+
+.aspect-4-3 {
+    height: 75vw;
+    max-width: 133.3vh;
+}
+
+.aspect-16-9 {
+    height: 56.25vw;
+    max-width: 177.7vh;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -2,30 +2,7 @@
 <html>
 <head>
     <title>Super Mario</title>
-    <style>
-        body {
-            background: #000;
-            margin: 0;
-        }
-
-        #screen {
-            display: block;
-            image-rendering: pixelated;
-            margin: auto;
-            width: 100vw;
-            max-height: 100vh;
-        }
-
-        .aspect-4-3 {
-            height: 75vw;
-            max-width: 133.3vh;
-        }
-
-        .aspect-16-9 {
-            height: 56.25vw;
-            max-width: 177.7vh;
-        }
-    </style>
+    <link rel="stylesheet" href="/css/main.css"/>
     <script type="module" src="/js/main.js"></script>
 </head>
 <body>

--- a/public/index.html
+++ b/public/index.html
@@ -11,13 +11,24 @@
         #screen {
             display: block;
             image-rendering: pixelated;
-            height: 100vh;
             margin: auto;
+            width: 100vw;
+            max-height: 100vh;
+        }
+
+        .aspect-4-3 {
+            height: 75vw;
+            max-width: 133.3vh;
+        }
+
+        .aspect-16-9 {
+            height: 56.25vw;
+            max-width: 177.7vh;
         }
     </style>
     <script type="module" src="/js/main.js"></script>
 </head>
 <body>
-    <canvas id="screen" width="256" height="240"></canvas>
+    <canvas id="screen" width="256" height="240" class="aspect-4-3"></canvas>
 </body>
 </html>


### PR DESCRIPTION
Aspect ratios for #screen canvas.

Supports 4:3 and 16:9.
Keeps aspect upon resizing.
Always full width or full height.
Canvas centered if window width is greater than allowed height.
No scrollbars (since it always fit).