### PR TITLE
Only play pipe.ogg when entering pipes.

### DIFF
--- a/public/js/traits/Pipe.js
+++ b/public/js/traits/Pipe.js
@@ -40,7 +40,6 @@ export default class Pipe extends Trait {
     }
 
     addTraveller(pipe, traveller) {
-        pipe.sounds.add('pipe');
 
         const pipeTraveller = traveller.traits.get(PipeTraveller);
         pipeTraveller.distance.set(0, 0);
@@ -73,6 +72,7 @@ export default class Pipe extends Trait {
                 (tBounds.left < pBounds.left || tBounds.right > pBounds.right)) {
                 return;
             }
+            pipe.sounds.add('pipe');
             this.addTraveller(pipe, traveller);
         }
     }


### PR DESCRIPTION
When exiting a pipe no sound should be played. Moved playing logic to collides method.